### PR TITLE
fix: always work with uppercased verbs

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -17,16 +17,16 @@ const makeSnykRequest = async (request: snykRequest) => {
         'Authorization': 'token '+userConfig.token,
         'User-Agent': 'tech-services/snyk-prevent/1.0'
       }
-    
+
     const apiClient = axios.create({
         baseURL: userConfig.endpoint,
         responseType: 'json',
         headers: {...requestHeaders, ...request.headers }
       });
-      
+
     try {
         let res;
-        switch(request.verb){
+        switch(request.verb.toUpperCase()){
             case "GET":
                 res = await apiClient.get(request.url)
                 break;
@@ -43,7 +43,7 @@ const makeSnykRequest = async (request: snykRequest) => {
                 throw new Error.GenericError('Unexpected http command')
         }
         return res?.data
-        
+
     } catch (err) {
         switch(err.response.status){
             case 401:
@@ -56,8 +56,8 @@ const makeSnykRequest = async (request: snykRequest) => {
                 throw new Error.GenericError(err)
         }
     }
-    
-    
+
+
 }
 
 const getConfig = () => {
@@ -69,5 +69,5 @@ const getConfig = () => {
 export {
     makeSnykRequest,
     getConfig,
-    snykRequest  
-} 
+    snykRequest
+}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Always uppercase the verbs in case they are passed in lowercased.