### PR TITLE
fix: return entire response instead of just data

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -42,7 +42,7 @@ const makeSnykRequest = async (request: snykRequest) => {
             default:
                 throw new Error.GenericError('Unexpected http command')
         }
-        return res?.data
+        return res //res?.data
         
     } catch (err) {
         switch(err.response.status){

--- a/test/lib/request/request.test.ts
+++ b/test/lib/request/request.test.ts
@@ -71,7 +71,7 @@ describe('Test Snyk Utils make request properly', () => {
         .toString(),
     );
 
-    expect(_.isEqual(response, fixturesJSON)).toBeTruthy();
+    expect(_.isEqual(response.data, fixturesJSON)).toBeTruthy();
   });
   it('Test POST command on /', async () => {
     const bodyToSend = {
@@ -82,7 +82,7 @@ describe('Test Snyk Utils make request properly', () => {
       url: '/',
       body: JSON.stringify(bodyToSend),
     });
-    expect(_.isEqual(response, bodyToSend)).toBeTruthy();
+    expect(_.isEqual(response.data, bodyToSend)).toBeTruthy();
   });
 });
 

--- a/test/lib/requestManager/normal-flows.test.ts
+++ b/test/lib/requestManager/normal-flows.test.ts
@@ -69,7 +69,7 @@ describe('Testing Request Flows', () => {
           .toString(),
       );
 
-      expect(_.isEqual(responseSync, fixturesJSON)).toBeTruthy();
+      expect(_.isEqual(responseSync.data, fixturesJSON)).toBeTruthy();
     } catch (err) {
       throw new Error(err);
     }
@@ -91,8 +91,8 @@ describe('Testing Request Flows', () => {
           .toString(),
       );
 
-      expect(_.isEqual(responseSync1, fixturesJSON)).toBeTruthy();
-      expect(_.isEqual(responseSync2, fixturesJSON)).toBeTruthy();
+      expect(_.isEqual(responseSync1.data, fixturesJSON)).toBeTruthy();
+      expect(_.isEqual(responseSync2.data, fixturesJSON)).toBeTruthy();
     } catch (err) {
       console.log(err);
       throw new Error(err);
@@ -111,7 +111,7 @@ describe('Testing Request Flows', () => {
     try {
       // dummypath is slowed down 1sec to verify that the response array respect the order of request
       // waits for all request to be done and return an array of response in the same order.
-      const results = await requestManager.requestBulk([
+      const results: any = await requestManager.requestBulk([
         { verb: 'GET', url: '/dummypath' },
         {
           verb: 'POST',
@@ -132,9 +132,9 @@ describe('Testing Request Flows', () => {
           .toString(),
       );
 
-      expect(results[0]).toEqual('dummypath slowed down');
-      expect(_.isEqual(results[2], fixturesJSON1)).toBeTruthy();
-      expect(_.isEqual(results[1], fixturesJSON2)).toBeTruthy();
+      expect(results[0].data).toEqual('dummypath slowed down');
+      expect(_.isEqual(results[2].data, fixturesJSON1)).toBeTruthy();
+      expect(_.isEqual(results[1].data, fixturesJSON2)).toBeTruthy();
     } catch (resultsWithError) {
       console.log(resultsWithError);
     }
@@ -159,8 +159,8 @@ describe('Testing Request Flows', () => {
           .readFileSync(fixturesFolderPath + 'apiResponses/projectIssues.json')
           .toString(),
       );
-      expect(_.isEqual(resultsWithError[2], fixturesJSON2)).toBeTruthy();
-      expect(resultsWithError[1]).toEqual('dummypath slowed down');
+      expect(_.isEqual(resultsWithError[2].data, fixturesJSON2)).toBeTruthy();
+      expect(resultsWithError[1].data).toEqual('dummypath slowed down');
       expect(resultsWithError[0]).toBeInstanceOf(RequestsManagerNotFoundError);
     }
   });
@@ -197,7 +197,7 @@ describe('Testing Request Flows', () => {
         ) {
           try {
             Array.from(responseMap.values()).forEach((response, index) => {
-              expect(response).toEqual(expectedResponse[index]);
+              expect(response.data).toEqual(expectedResponse[index]);
             });
             done();
           } catch (err) {

--- a/test/lib/requestManager/retries.test.ts
+++ b/test/lib/requestManager/retries.test.ts
@@ -26,7 +26,7 @@ describe('Testing Request Retries', () => {
         verb: 'POST',
         url: '/apierror',
       });
-      expect(response).toEqual(
+      expect(response.data).toEqual(
         JSON.parse(
           fs
             .readFileSync(fixturesFolderPath + 'apiResponses/general-doc.json')
@@ -64,7 +64,7 @@ describe('Testing Request Retries', () => {
         verb: 'POST',
         url: '/apierror',
       });
-      expect(response).toEqual(
+      expect(response.data).toEqual(
         JSON.parse(
           fs
             .readFileSync(fixturesFolderPath + 'apiResponses/general-doc.json')
@@ -105,7 +105,7 @@ describe('Testing Request Retries', () => {
         verb: 'POST',
         url: '/apierror',
       });
-      expect(response).toThrowError();
+      expect(response.data).toThrowError();
     } catch (err) {
       expect(err).toBeInstanceOf(RequestsManagerApiError);
       expect(hasReached5thTime).toBeTruthy();


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Returns the whole response so you get headers and everything instead of just data.
