### PR TITLE
fix: fix unsafe object get

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -44,7 +44,7 @@ const makeSnykRequest = async (request: snykRequest) => {
         }
         return res
     } catch (err) {
-        switch(err.response.status){
+        switch(err.response?.status){
             case 401:
                 throw new Error.ApiAuthenticationError(err)
             case 404:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
When the err did not have a `response` the whole thing threw with an `Unclassified` error. With the safe get the generic default errors bubble up.