### PR TITLE
feat: Allow snyk-token override in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ Following the same setup as snyk CLI, it uses the token stored in your system af
 \
 Same thing if you need to designate a different API base url to your onprem instance via `snyk config set endpoint` or `SNYK_API` to `https://yourhostname/api`
 
+>Make sure to omit the base endpoint url when you define url to hit.
+
 ### 1 - Construct your manager
 
-    const requestManager = new requestsManager(20, period = 100, maxRetryCount = 10)
+
+    const requestManager = new requestsManager()
 
 Default values if using `new requestsManager()`\
-    `requestsManager(burstSize = 10, period = 500, maxRetryCount = 5)`
+    `requestsManager(snykToken = '', burstSize = 10, period = 500, maxRetryCount = 5)`
+
+
 
 ### 2 - Single shot request
 Fire off your request and await it's result.
@@ -137,3 +142,22 @@ If not defining custom channel name, default channel name is used in the backend
 
 
 Above will only show result of call to `/` as listener is only for 'test-channel'
+
+
+### Customize token and or snyk token
+While instantiating your manager
+
+#### Customize queue size and intervals
+```
+const requestManager = new requestsManager('',20, 100, 10)
+```
+
+#### Customize snyk token
+```
+const requestManager = new requestsManager('21346-1234-1234-1234')
+```
+
+#### Customize snyk token and queue|intervals|retries
+```
+const requestManager = new requestsManager('21346-1234-1234-1234',20, 100, 10)
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Same thing if you need to designate a different API base url to your onprem inst
     const requestManager = new requestsManager()
 
 Default values if using `new requestsManager()`\
-    `requestsManager(snykToken = '', burstSize = 10, period = 500, maxRetryCount = 5)`
+    `snykToken = '', burstSize = 10, period = 500, maxRetryCount = 5`
 
 
 
@@ -149,15 +149,15 @@ While instantiating your manager
 
 #### Customize queue size and intervals
 ```
-const requestManager = new requestsManager('',20, 100, 10)
+const requestManager = new requestsManager({burstSize: 20, period: 100, maxRetryCount: 10})
 ```
 
 #### Customize snyk token
 ```
-const requestManager = new requestsManager('21346-1234-1234-1234')
+const requestManager = new requestsManager({snykToken:'21346-1234-1234-1234')
 ```
 
 #### Customize snyk token and queue|intervals|retries
 ```
-const requestManager = new requestsManager('21346-1234-1234-1234',20, 100, 10)
+const requestManager = new requestsManager({snykToken:'21346-1234-1234-1234', burstSize: 20, period: 100, maxRetryCount: 10})
 ```

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -10,14 +10,15 @@ interface snykRequest {
     requestId?: string
 }
 
-const makeSnykRequest = async (request: snykRequest) => {
+const makeSnykRequest = async (request: snykRequest, snykToken: string = '') => {
     const userConfig = getConfig()
+    const token = snykToken == '' ? userConfig.token : snykToken
+    
     const requestHeaders: Object = {
         'Content-Type': 'application/json',
-        'Authorization': 'token '+userConfig.token,
+        'Authorization': 'token '+ token,
         'User-Agent': 'tech-services/snyk-prevent/1.0'
-      }
-
+    }
     const apiClient = axios.create({
         baseURL: userConfig.endpoint,
         responseType: 'json',

--- a/test/lib/requestManager/rate-limits.test.ts
+++ b/test/lib/requestManager/rate-limits.test.ts
@@ -55,7 +55,7 @@ beforeAll(() => {
 describe('Testing Request Rate limiting', () => {
   describe('Testing Sync requests', () => {
     it('Overall rate limiting in sync requests - burst size 1', async () => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const t0 = Date.now();
 
       await requestManager.request({ verb: 'GET', url: '/' });
@@ -72,7 +72,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in sync requests - burst size 1 - with slow request', async () => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const t0 = Date.now();
 
       await requestManager.request({ verb: 'GET', url: '/' });
@@ -89,7 +89,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in sync requests - burst size 2', async () => {
-      const requestManager = new requestsManager(2, 200);
+      const requestManager = new requestsManager({ burstSize: 2, period: 200 });
       const t0 = Date.now();
 
       await requestManager.request({ verb: 'GET', url: '/' });
@@ -106,7 +106,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in sync requests - burst size 4', async () => {
-      const requestManager = new requestsManager(4, 200);
+      const requestManager = new requestsManager({ burstSize: 4, period: 200 });
       const t0 = Date.now();
 
       await requestManager.request({ verb: 'GET', url: '/' });
@@ -123,9 +123,8 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in bulk sync requests - burst size 1', async () => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const t0 = Date.now();
-
       await requestManager.requestBulk([
         { verb: 'GET', url: '/' },
         { verb: 'GET', url: '/' },
@@ -142,7 +141,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in bulk sync requests - burst size 1 with slow request', async () => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const t0 = Date.now();
 
       await requestManager.requestBulk([
@@ -161,7 +160,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in bulk sync requests - burst size 2', async () => {
-      const requestManager = new requestsManager(2, 200);
+      const requestManager = new requestsManager({ burstSize: 2, period: 200 });
       const t0 = Date.now();
 
       await requestManager.requestBulk([
@@ -180,7 +179,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in bulk sync requests - burst size 4', async () => {
-      const requestManager = new requestsManager(4, 200);
+      const requestManager = new requestsManager({ burstSize: 4, period: 200 });
       const t0 = Date.now();
 
       await requestManager.requestBulk([
@@ -201,7 +200,7 @@ describe('Testing Request Rate limiting', () => {
 
   describe('Testing Stream requests', () => {
     it('Overall rate limiting in sync requests - burst size 1', async (done) => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -263,7 +262,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in sync requests - burst size 1 with slow request', async (done) => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -322,7 +321,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in sync requests - burst size 2', async (done) => {
-      const requestManager = new requestsManager(2, 200);
+      const requestManager = new requestsManager({ burstSize: 2, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -384,7 +383,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in sync requests - burst size 4', async (done) => {
-      const requestManager = new requestsManager(4, 200);
+      const requestManager = new requestsManager({ burstSize: 4, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -448,7 +447,7 @@ describe('Testing Request Rate limiting', () => {
 
   describe('Testing Stream + Sync requests', () => {
     it('Overall rate limiting in mixed (sync+stream) requests - burst size 1', async (done) => {
-      const requestManager = new requestsManager(1, 200);
+      const requestManager = new requestsManager({ burstSize: 1, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -520,7 +519,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in mixed (sync+stream) requests - burst size 2', async (done) => {
-      const requestManager = new requestsManager(2, 200);
+      const requestManager = new requestsManager({ burstSize: 2, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -592,7 +591,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in mixed (sync+stream) requests - burst size 4', async (done) => {
-      const requestManager = new requestsManager(4, 200);
+      const requestManager = new requestsManager({ burstSize: 4, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 
@@ -664,7 +663,7 @@ describe('Testing Request Rate limiting', () => {
     });
 
     it('Overall rate limiting in mixed (sync+bulk+stream) requests - burst size 4', async (done) => {
-      const requestManager = new requestsManager(4, 200);
+      const requestManager = new requestsManager({ burstSize: 4, period: 200 });
       const responseIdArray: Array<string> = [];
       const t0 = Date.now();
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allows to specify the SNYK Token in the requestManager instantiation.
