### PR TITLE
fix: Return data from api along with error

### DIFF
--- a/src/lib/customErrors/apiError.ts
+++ b/src/lib/customErrors/apiError.ts
@@ -1,34 +1,42 @@
 
 
 class ApiError extends Error {
+    data: {}
     constructor(message: any){
         super(message)
         this.name = "ApiError"
         this.message = (message || "")
+        this.data = (message.response?.data || "")
     }
 }
 
 class ApiAuthenticationError extends Error {
+    data: {}
     constructor(message: any){
         super(message)
         this.name = "ApiAuthenticationError"
         this.message = (message || "")
+        this.data = (message.response?.data || "")
     }
 }
 
 class NotFoundError extends Error {
+    data: {}
     constructor(message: any){
         super(message)
         this.name = "NotFoundError"
         this.message = (message || "")
+        this.data = (message.response?.data || "")
     }
 }
 
 class GenericError extends Error {
+    data: {}
     constructor(message: any){
         super(message)
         this.name = "Unknown"
         this.message = (message || "")
+        this.data = (message.response?.data || "")
     }
 }
 

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -49,7 +49,7 @@ const makeSnykRequest = async (request: snykRequest, snykToken: string = '') => 
             case 401:
                 throw new Error.ApiAuthenticationError(err)
             case 404:
-                throw new Error.NotFoundError("Snyk API - Could not find this resource")
+                throw new Error.NotFoundError(err)
             case 500:
                 throw new Error.ApiError(err)
             default:

--- a/test/lib/request/request.test.ts
+++ b/test/lib/request/request.test.ts
@@ -96,6 +96,7 @@ describe('Test Snyk Utils error handling/classification', () => {
     try {
       await makeSnykRequest({ verb: 'GET', url: '/xyz', body: '' });
     } catch (err) {
+      expect(err.data).toEqual(404);
       expect(err).toBeInstanceOf(NotFoundError);
     }
   });
@@ -111,6 +112,7 @@ describe('Test Snyk Utils error handling/classification', () => {
         body: JSON.stringify(bodyToSend),
       });
     } catch (err) {
+      expect(err.data).toEqual(404);
       expect(err).toBeInstanceOf(NotFoundError);
     }
   });
@@ -119,6 +121,7 @@ describe('Test Snyk Utils error handling/classification', () => {
     try {
       await makeSnykRequest({ verb: 'GET', url: '/apierror' });
     } catch (err) {
+      expect(err.data).toEqual(500);
       expect(err).toBeInstanceOf(ApiError);
     }
   });
@@ -133,6 +136,7 @@ describe('Test Snyk Utils error handling/classification', () => {
         body: JSON.stringify(bodyToSend),
       });
     } catch (err) {
+      expect(err.data).toEqual(500);
       expect(err).toBeInstanceOf(ApiError);
     }
   });
@@ -141,6 +145,7 @@ describe('Test Snyk Utils error handling/classification', () => {
     try {
       await makeSnykRequest({ verb: 'GET', url: '/apiautherror' });
     } catch (err) {
+      expect(err.data).toEqual(401);
       expect(err).toBeInstanceOf(ApiAuthenticationError);
     }
   });
@@ -155,6 +160,7 @@ describe('Test Snyk Utils error handling/classification', () => {
         body: JSON.stringify(bodyToSend),
       });
     } catch (err) {
+      expect(err.data).toEqual(401);
       expect(err).toBeInstanceOf(ApiAuthenticationError);
     }
   });
@@ -163,6 +169,7 @@ describe('Test Snyk Utils error handling/classification', () => {
     try {
       await makeSnykRequest({ verb: 'GET', url: '/genericerror' });
     } catch (err) {
+      expect(err.data).toEqual(512);
       expect(err).toBeInstanceOf(GenericError);
     }
   });
@@ -177,6 +184,7 @@ describe('Test Snyk Utils error handling/classification', () => {
         body: JSON.stringify(bodyToSend),
       });
     } catch (err) {
+      expect(err.data).toEqual(512);
       expect(err).toBeInstanceOf(GenericError);
     }
   });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Returns the data from API if error instead of swallowing it.

