### PR TITLE
fix: Fix useragent prefix trailing slash

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -26,11 +26,11 @@ const makeSnykRequest = async (request: snykRequest, snykToken: string = '', use
     const token = snykToken == '' ? userConfig.token : snykToken
     
     let topParentModuleName = getTopParentModuleName(module.parent)
-
+    const userAgentPrefixChecked = userAgentPrefix != '' && !userAgentPrefix.endsWith('/') ? userAgentPrefix+'/': userAgentPrefix
     const requestHeaders: Object = {
         'Content-Type': 'application/json',
         'Authorization': 'token '+ token,
-        'User-Agent': `${topParentModuleName}${userAgentPrefix}tech-services/snyk-request-manager/1.0`
+        'User-Agent': `${topParentModuleName}${userAgentPrefixChecked}tech-services/snyk-request-manager/1.0`
     }
     
     const apiClient = axios.create({


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes trailing slash in useragent prefix.
