### PR TITLE
chore: pin axios to 022 before breaking changes in minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@snyk/configstore": "^3.2.0-rc1",
     "@types/debug": "^4.1.7",
     "@types/uuid": "^7.0.3",
-    "axios": "^0.21.1",
+    "axios": "0.22.0",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "leaky-bucket-queue": "0.0.2",


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pins axios to 0.22 before breaking changes in 0.23 and 0.24 going in, despite minor semver bump only....
