### PR TITLE
chore: pin axios to 0.21.4 before breaking changes in minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@snyk/configstore": "^3.2.0-rc1",
     "@types/debug": "^4.1.7",
     "@types/uuid": "^7.0.3",
-    "axios": "^0.21.1",
+    "axios": "0.21.4",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "leaky-bucket-queue": "0.0.2",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pins axios to non braking version
