### PR TITLE
feat: support REST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ const requestManager = new requestsManager({burstSize: 20, period: 100, maxRetry
 const requestManager = new requestsManager({snykToken:'21346-1234-1234-1234')
 ```
 
+
+#### Customize to use REST api endpoint
+
+Each request can be opted in to use the new REST Snyk API, which defaults to 'https://api.snyk.io/rest/' and is automatically calculated from the `SNYK_API` or `endpoint` configuration by reusing the same host.
+```
+const res = await requestManager.request({verb: "GET", url: '/url', useRESTApi: true})
+```
+
+
 #### Customize snyk token and queue|intervals|retries
 
 ```

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -6,13 +6,14 @@ import * as Error from '../customErrors/apiError';
 import 'global-agent/bootstrap';
 
 const DEFAULT_API = 'https://snyk.io/api/v1';
-
+const DEFAULT_REST_API = 'https://api.snyk.io/rest/';
 interface SnykRequest {
   verb: string;
   url: string;
   body?: string;
   headers?: Record<string, any>;
   requestId?: string;
+  useRESTApi?: boolean;
 }
 
 const getTopParentModuleName = (parent: NodeModule | null): string => {
@@ -31,6 +32,7 @@ const makeSnykRequest = async (
   request: SnykRequest,
   snykToken = '',
   apiUrl = DEFAULT_API,
+  apiUrlREST = DEFAULT_REST_API,
   userAgentPrefix = '',
 ): Promise<AxiosResponse<any>> => {
   const topParentModuleName = getTopParentModuleName(module.parent as any);
@@ -45,7 +47,7 @@ const makeSnykRequest = async (
   };
 
   const apiClient = axios.create({
-    baseURL: apiUrl,
+    baseURL: request.useRESTApi ? apiUrlREST : apiUrl,
     responseType: 'json',
     headers: { ...requestHeaders, ...request.headers },
   });

--- a/test/lib/request/rest-request.test.ts
+++ b/test/lib/request/rest-request.test.ts
@@ -12,7 +12,7 @@ import {
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 beforeEach(() => {
-  return nock('https://snyk.io')
+  return nock('https://api.snyk.io')
     .persist()
     .get(/\/xyz/)
     .reply(404, '404')
@@ -37,7 +37,7 @@ beforeEach(() => {
     .post(/^(?!.*xyz).*$/)
     .reply(200, (uri, requestBody) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/rest/':
           return requestBody;
           break;
         default:
@@ -46,7 +46,7 @@ beforeEach(() => {
     .get(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/rest/':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/general-doc.json',
           );
@@ -70,7 +70,7 @@ afterEach(() => {
 describe('Test Snyk Utils make request properly', () => {
   it('Test GET command on /', async () => {
     const response = await makeSnykRequest(
-      { verb: 'GET', url: '/' },
+      { verb: 'GET', url: '/', useRESTApi: true },
       'token123',
     );
     const fixturesJSON = JSON.parse(
@@ -78,7 +78,6 @@ describe('Test Snyk Utils make request properly', () => {
         .readFileSync(fixturesFolderPath + 'apiResponses/general-doc.json')
         .toString(),
     );
-
     expect(response.data).toEqual(fixturesJSON);
   });
   it('Test POST command on /', async () => {
@@ -90,6 +89,7 @@ describe('Test Snyk Utils make request properly', () => {
         verb: 'POST',
         url: '/',
         body: JSON.stringify(bodyToSend),
+        useRESTApi: true,
       },
       'token123',
     );
@@ -100,7 +100,10 @@ describe('Test Snyk Utils make request properly', () => {
 describe('Test Snyk Utils error handling/classification', () => {
   it('Test NotFoundError on GET command', async () => {
     try {
-      await makeSnykRequest({ verb: 'GET', url: '/xyz', body: '' }, 'token123');
+      await makeSnykRequest(
+        { verb: 'GET', url: '/xyz', body: '', useRESTApi: true },
+        'token123',
+      );
     } catch (err) {
       expect(err.data).toEqual(404);
       expect(err).toBeInstanceOf(NotFoundError);
@@ -117,6 +120,7 @@ describe('Test Snyk Utils error handling/classification', () => {
           verb: 'POST',
           url: '/xyz',
           body: JSON.stringify(bodyToSend),
+          useRESTApi: true,
         },
         'token123',
       );
@@ -128,7 +132,10 @@ describe('Test Snyk Utils error handling/classification', () => {
 
   it('Test ApiError on GET command', async () => {
     try {
-      await makeSnykRequest({ verb: 'GET', url: '/apierror' }, 'token123');
+      await makeSnykRequest(
+        { verb: 'GET', url: '/apierror', useRESTApi: true },
+        'token123',
+      );
     } catch (err) {
       expect(err.data).toEqual(500);
       expect(err).toBeInstanceOf(ApiError);
@@ -144,6 +151,7 @@ describe('Test Snyk Utils error handling/classification', () => {
           verb: 'POST',
           url: '/apierror',
           body: JSON.stringify(bodyToSend),
+          useRESTApi: true,
         },
         'token123',
       );
@@ -155,7 +163,10 @@ describe('Test Snyk Utils error handling/classification', () => {
 
   it('Test ApiAuthenticationError on GET command', async () => {
     try {
-      await makeSnykRequest({ verb: 'GET', url: '/apiautherror' }, 'token123');
+      await makeSnykRequest(
+        { verb: 'GET', url: '/apiautherror', useRESTApi: true },
+        'token123',
+      );
     } catch (err) {
       expect(err.data).toEqual(401);
       expect(err).toBeInstanceOf(ApiAuthenticationError);
@@ -171,6 +182,7 @@ describe('Test Snyk Utils error handling/classification', () => {
           verb: 'POST',
           url: '/apiautherror',
           body: JSON.stringify(bodyToSend),
+          useRESTApi: true,
         },
         'token123',
       );
@@ -182,7 +194,10 @@ describe('Test Snyk Utils error handling/classification', () => {
 
   it('Test GenericError on GET command', async () => {
     try {
-      await makeSnykRequest({ verb: 'GET', url: '/genericerror' }, 'token123');
+      await makeSnykRequest(
+        { verb: 'GET', url: '/genericerror', useRESTApi: true },
+        'token123',
+      );
     } catch (err) {
       expect(err.data).toEqual(512);
       expect(err).toBeInstanceOf(GenericError);
@@ -198,6 +213,7 @@ describe('Test Snyk Utils error handling/classification', () => {
           verb: 'POST',
           url: '/genericerror',
           body: JSON.stringify(bodyToSend),
+          useRESTApi: true,
         },
         'token123',
       );


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Add support for Snyk REST APIs by letting each request specify if it uses the REST or v1 url. REST API url is calculated automatically from the API url for v1 to retain the same host.

Needed for REST support in https://github.com/snyk-tech-services/snyk-api-import/pull/342