### PR TITLE
Feat/add oauth support

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -42,6 +42,7 @@ const getTopParentModuleName = (parent: NodeModule | null): string => {
 const makeSnykRequest = async (
   request: SnykRequest,
   snykToken = '',
+  oauthBearerToken = '',
   apiUrl = DEFAULT_API,
   apiUrlREST = DEFAULT_REST_API,
   userAgentPrefix = '',
@@ -57,12 +58,20 @@ const makeSnykRequest = async (
     userAgentPrefix != '' && !userAgentPrefix.endsWith('/')
       ? userAgentPrefix + '/'
       : userAgentPrefix;
+
+  // prioritize snykToken but use oauthBearerToken if snykToken isn't provided
+  const authorizationToken = snykToken
+    ? `token ${snykToken}`
+    : oauthBearerToken
+    ? `Bearer ${oauthBearerToken}`
+    : '';
+
   const requestHeaders: Record<string, any> = {
     'Content-Type':
       request.useRESTApi && request.body
         ? 'application/vnd.api+json'
         : 'application/json',
-    Authorization: 'token ' + snykToken,
+    Authorization: authorizationToken,
     'User-Agent': `${topParentModuleName}${userAgentPrefixChecked}tech-services/snyk-request-manager/1.0`,
   };
   let apiClient;
@@ -70,7 +79,10 @@ const makeSnykRequest = async (
     apiClient = axios.create({
       baseURL: request.useRESTApi ? apiUrlREST : apiUrl,
       responseType: 'json',
-      headers: { ...requestHeaders, ...request.headers },
+      headers: {
+        ...requestHeaders,
+        ...request.headers,
+      },
       transitional: {
         clarifyTimeoutError: true,
       },
@@ -81,7 +93,10 @@ const makeSnykRequest = async (
     apiClient = axios.create({
       baseURL: request.useRESTApi ? apiUrlREST : apiUrl,
       responseType: 'json',
-      headers: { ...requestHeaders, ...request.headers },
+      headers: {
+        ...requestHeaders,
+        ...request.headers,
+      },
       transitional: {
         clarifyTimeoutError: true,
       },

--- a/src/lib/request/requestManager.ts
+++ b/src/lib/request/requestManager.ts
@@ -47,7 +47,7 @@ function getRESTAPI(endpoint: string): string {
 }
 
 function getOauthToken(): string {
-  const oauthToken: string = process.env.OAUTH_BEARER_TOKEN || '';
+  const oauthToken: string = process.env.SNYK_OAUTH_TOKEN || '';
   return oauthToken;
 }
 

--- a/test/lib/request/request.test.ts
+++ b/test/lib/request/request.test.ts
@@ -229,3 +229,85 @@ describe('Test Snyk Utils error handling/classification', () => {
     }
   });
 });
+
+describe('Test makeSnykRequest with oauthBearerToken', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should set Bearer token in Authorization header when oauthBearerToken is provided for DEFAULT_API', async () => {
+    const testToken = 'test-oauth-token';
+    const request = {
+      verb: 'GET',
+      url: '/test-endpoint',
+    };
+
+    const scope = nock('https://api.snyk.io/v1')
+      .get('/test-endpoint')
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { success: true });
+
+    await makeSnykRequest(request, '', testToken);
+
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('should set Bearer token in Authorization header when oauthBearerToken is provided for DEFAULT_REST_API', async () => {
+    const testToken = 'test-oauth-token';
+    const request = {
+      verb: 'GET',
+      url: '/test-endpoint',
+      useRESTApi: true,
+    };
+
+    const scope = nock('https://api.snyk.io/rest/')
+      .get('/test-endpoint')
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { success: true });
+
+    await makeSnykRequest(request, '', testToken);
+
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('should prioritize snykToken over oauthBearerToken when both are provided for DEFAULT_API', async () => {
+    const snykToken = 'test-snyk-token';
+    const oauthToken = 'test-oauth-token';
+    const request = {
+      verb: 'GET',
+      url: '/test-endpoint',
+    };
+
+    const scope = nock('https://api.snyk.io/v1')
+      .get('/test-endpoint')
+      .matchHeader('Authorization', `token ${snykToken}`)
+      .reply(200, { success: true });
+
+    await makeSnykRequest(request, snykToken, oauthToken);
+
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('should prioritize snykToken over oauthBearerToken when both are provided for DEFAULT_REST_API', async () => {
+    const snykToken = 'test-snyk-token';
+    const oauthToken = 'test-oauth-token';
+    const request = {
+      verb: 'GET',
+      url: '/test-endpoint',
+      useRESTApi: true,
+    };
+
+    const scope = nock('https://api.snyk.io/rest/')
+      .get('/test-endpoint')
+      .matchHeader('Authorization', `token ${snykToken}`)
+      .reply(200, { success: true });
+
+    await makeSnykRequest(request, snykToken, oauthToken);
+
+    expect(scope.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This PR add functionality to pass an OAuth token with SNYK_OAUTH_TOKEN environment variable as long as a snyk token isn't passed. 

### Notes for the reviewer

Call the request manger and set a SNYK_OAUTH_TOKEN to any snyk endpoint.

### More information

- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
- [Link to documentation](https://github.com/snyk/snyk-request-manager/wiki/)

### Screenshots
