### PR TITLE
adding correct versioning to user-agent for tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "snyk-request-manager",
+  "version": "1.9.2",
   "description": "Rate controlled and retry enabled request manager to interact with Snyk APIs",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/packageVersion.ts
+++ b/src/lib/packageVersion.ts
@@ -1,0 +1,32 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Same version semantic-release writes into package.json before npm publish.
+ */
+function readPackageVersion(): string {
+  let dir: string = __dirname;
+  for (let i = 0; i < 10; i++) {
+    const pkgPath = path.join(dir, 'package.json');
+    try {
+      const raw = fs.readFileSync(pkgPath, 'utf8');
+      const pkg = JSON.parse(raw) as { name?: string; version?: string };
+      if (
+        pkg.name === 'snyk-request-manager' &&
+        typeof pkg.version === 'string'
+      ) {
+        return pkg.version;
+      }
+    } catch {
+      /* missing or unreadable */
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return '0.0.0';
+}
+
+export const PACKAGE_VERSION = readPackageVersion();

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse, isAxiosError } from 'axios';
 import type { Module } from 'module';
+import { PACKAGE_VERSION } from '../packageVersion';
 import * as Error from '../customErrors/apiError';
 
 // Fixes issue https://github.com/axios/axios/issues/3384
@@ -73,7 +74,7 @@ const makeSnykRequest = async (
         ? 'application/vnd.api+json'
         : 'application/json',
     Authorization: authorizationToken,
-    'User-Agent': `${topParentModuleName}${userAgentPrefixChecked}tech-services/snyk-request-manager/1.0`,
+    'User-Agent': `${topParentModuleName}${userAgentPrefixChecked}tech-services/snyk-request-manager/${PACKAGE_VERSION}`,
   };
   let apiClient;
   if (proxyUri) {

--- a/test/lib/request/rest-request.test.ts
+++ b/test/lib/request/rest-request.test.ts
@@ -12,6 +12,12 @@ import {
 } from '../../../src/lib/customErrors/apiError';
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
+
+const PACKAGE_JSON_VERSION = (
+  JSON.parse(
+    fs.readFileSync(path.join(__dirname, '../../../package.json'), 'utf8'),
+  ) as { version: string }
+).version;
 beforeEach(() => {
   return nock('https://api.snyk.io')
     .persist()
@@ -102,7 +108,7 @@ describe('Test Snyk Utils make request properly', () => {
       headers: {
         Authorization: 'token token123',
         'Content-Type': 'application/json',
-        'User-Agent': 'tech-services/snyk-request-manager/1.0',
+        'User-Agent': `tech-services/snyk-request-manager/${PACKAGE_JSON_VERSION}`,
       },
       responseType: 'json',
       timeout: 30000,
@@ -130,7 +136,7 @@ describe('Test Snyk Utils make request properly', () => {
       headers: {
         Authorization: 'token token123',
         'Content-Type': 'application/vnd.api+json',
-        'User-Agent': 'tech-services/snyk-request-manager/1.0',
+        'User-Agent': `tech-services/snyk-request-manager/${PACKAGE_JSON_VERSION}`,
       },
       responseType: 'json',
       timeout: 30000,
@@ -158,7 +164,7 @@ describe('Test Snyk Utils make request properly', () => {
       headers: {
         Authorization: 'token token123',
         'Content-Type': 'application/vnd.api+json',
-        'User-Agent': 'tech-services/snyk-request-manager/1.0',
+        'User-Agent': `tech-services/snyk-request-manager/${PACKAGE_JSON_VERSION}`,
       },
       responseType: 'json',
       timeout: 30000,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This pull request updates the way the `User-Agent` header is set for outgoing requests, ensuring it always reflects the current package version from `package.json` rather than a hardcoded value. It also adds logic to dynamically read the package version at runtime and updates related tests to verify this behavior.

**User-Agent Header Versioning:**

- The `User-Agent` header in `makeSnykRequest` is now set using the actual package version from `package.json` instead of a hardcoded string. This ensures accurate version reporting for all requests.

**Dynamic Version Retrieval:**

- Introduced a new utility in `src/lib/packageVersion.ts` that locates and reads the `version` field from the nearest `package.json`, exporting it as `PACKAGE_VERSION`.
- Updated `src/lib/request/request.ts` to import and use `PACKAGE_VERSION` for the `User-Agent` header.

**Test Updates:**

- Updated tests in `test/lib/request/rest-request.test.ts` to dynamically read the version from `package.json` and verify that the `User-Agent` header contains the correct version. [[1]](diffhunk://#diff-a985d588668740b6ca7577481778ddfbdc0ecd9acc9d2e4180add4e74b946e44R15-R20) [[2]](diffhunk://#diff-a985d588668740b6ca7577481778ddfbdc0ecd9acc9d2e4180add4e74b946e44L105-R111) [[3]](diffhunk://#diff-a985d588668740b6ca7577481778ddfbdc0ecd9acc9d2e4180add4e74b946e44L133-R139) [[4]](diffhunk://#diff-a985d588668740b6ca7577481778ddfbdc0ecd9acc9d2e4180add4e74b946e44L161-R167)

**Version Bump:**

- Bumped the package version to `1.9.2` in `package.json`.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
- [Link to documentation](https://github.com/snyk/snyk-request-manager/wiki/)

### Screenshots

_Visuals that may help the reviewer_
