### PR TITLE
Bump version from 1.9.2 to 1.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-request-manager",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Rate controlled and retry enabled request manager to interact with Snyk APIs",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the `snyk-request-manager` package from 1.9.2 to 1.9.3. This is a standard version bump, likely reflecting recent changes or fixes.changed the way user-agent pulls it's version, but semantic-release didn't seem to bump this version as expected. maybe this needs to be done manually?

